### PR TITLE
add proper error sets

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -19,7 +19,7 @@ pub const ParseError = error{
     InvalidCodepoint,
 } || LexError || AllocError;
 
-pub const DecodingError = error{MismatchedType, MissingField} || ParseError;
+pub const DecodingError = error{ MismatchedType, MissingField } || ParseError;
 
 fn locToIndex(src: []const u8, loc: lex.Loc) usize {
     var line: usize = 1;


### PR DESCRIPTION
This properly declares an error set on almost[^1] every public facing function and on private ones, where there is little ambiguity.

This has several advantages over the inferred error set:
- Catching typos. `decodeValue` was using `error.MismatchedType` while `decodeTable` used `error.MismatchedTypes`
- Make it easier to incorporate `tomlz`'s error set into other error sets, e.g. if someone wants to declare a `ConfigError`

I renamed `not_utf8` from `Lexer.init` into `NotUTF8` and `not_array` from `Table.getOrPutArray` into `NotArray`. This is technically a breaking change, let me know if you want it reverted.

[^1]: `Lexer.init` still uses an inferred set, because declaring a set with a single error seemed weird