### PR TITLE
update to latest zig master

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
           rec {
             devShell = pkgs.mkShell {
               buildInputs = (with pkgs; [
-                zigpkgs.master-2023-06-20
+                zigpkgs.master-2023-06-23
                 zlspkgs.default
                 bashInteractive
                 gdb

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -35,7 +35,7 @@ fn jsonValueEquality(actual: *const std.json.Value, expected: *const std.json.Va
         .bool => |a| return a == expected.bool,
         .float => |f| return switch (expected.*) {
             .float => |f2| f == f2,
-            .integer => |i| f == @intToFloat(f64, i),
+            .integer => |i| f == @floatFromInt(f64, i),
             else => false,
         },
         .null, .number_string => return false,


### PR DESCRIPTION
The @enumToInt built-in was [just](https://github.com/ziglang/zig/commit/a6c8ee5231230947c928bbe1c6a39eb6e1bb9c5b) renamed to @intFromEnum.
Since I still don't have nix, you'll have to update the lockfile again.

Thanks for this library btw :)