### PR TITLE
Support for zig 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 zig-out/
 zig-cache/
+.zig-cache/
 .zigmod
 deps.zig
 .gyro

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # tomlz
+
 A TOML parser for Zig targeting TOML v1.0.0, an easy API and safety.
 Also supports encoding/serializing values(implemented by @0x5a4)!
 
@@ -25,7 +26,7 @@ const s = try tomlz.decode(S, gpa,
 
 // serialize a value like this (also see the examples)
 try tomlz.serialize(
-    gpa, 
+    gpa,
     std.io.getStdout.writer()
     s,
 );
@@ -34,6 +35,7 @@ try tomlz.serialize(
 ```
 
 ## Current status
+
 All types other than datetimes are supported. We pass 321/334 of the
 [toml tests](https://github.com/BurntSushi/toml-test) 11 of those are due to not
 having datetime support and the other two are minor lexing issues (allowing
@@ -45,15 +47,17 @@ arrays and strings.
 
 The Serializer allows encoding every kind of zig type, overwriting it's default behaviour
 by implementing a function called `tomlzSerialize`, has the option to work
-without an allocator and can therefore even work at `comptime`! 
+without an allocator and can therefore even work at `comptime`!
 Note that for some types like `std.HashMap` its not possible to just encode
 all their fields, so custom logic is needed. We can't provide this, but it's not
 too difficult to implement it yourself(See examples).
 
 ## Installation
+
 tomlz supports being included as a module.
 
-Create a file called `build.zig.zon` if you do not already have one, and add `tomlz` as a dependency  
+Create a file called `build.zig.zon` if you do not already have one, and add `tomlz` as a dependency
+
 ```
 .{
     .name = "myproject",
@@ -66,10 +70,12 @@ Create a file called `build.zig.zon` if you do not already have one, and add `to
     }
 }
 ```
+
 You'll have to replace the `<commit-hash>` part with an actual, recent commit-hash.
 The hash also needs changing, but `zig build` will complain and give you the correct one.
 
 In your `build.zig` file create and use the dependency
+
 ```
 pub fn build(b: *std.Build) void {
     // ... setup ...
@@ -79,15 +85,17 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    // add the tomlz module 
-    exe.addModule("tomlz", tomlz.module("tomlz"));
+    // add the tomlz module
+    exe.root_module.addImport("tomlz", tomlz.module("tomlz"));
 
     // .. continue ...
 }
 ```
 
 ## Usage
+
 ### Table
+
 We currently provide a single entry point for parsing which returns a toml
 `Table` type. This type has helper methods for getting values out:
 
@@ -118,6 +126,7 @@ A simple example is
 [provided](https://github.com/mattyhall/tomlz/tree/main/examples/simple/).
 
 ### Decode
+
 ```zig
 const std = @import("std");
 const tomlz = @import("tomlz");
@@ -172,14 +181,17 @@ defer s.deinit(gpa);
 ```
 
 ### Encode
+
 Have a look at [the example](examples/serialize/src/main.zig).
 
 ## Goals and non-goals
+
 Goals and non-goals are subject to change based on how the project is used and
 my own time constraints. If you feel a goal or non-goal isn't quite right please
 open an issue and we can discuss it.
 
 ### Goals
+
 - TOML v1.0.0. The datetime portion of this is probably going to be
   unachievable until Zig gets a good standard library type for it or a library
   gets dominance. Other than that however we should pass all the
@@ -199,6 +211,7 @@ open an issue and we can discuss it.
 - Good error messages
 
 ### Non-goals
+
 - Super duper performance. We want to be as performant as possible without
   making the code harder to read. It is unlikely that parsing a TOML file is
   going to be the bottleneck in your application so "good" performance should be

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) !void {
+pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
@@ -12,7 +12,7 @@ pub fn build(b: *std.build.Builder) !void {
     });
     b.installArtifact(lib);
 
-    _ = b.addModule("tomlz", .{ .source_file = .{ .path = "src/main.zig" } });
+    _ = b.addModule("tomlz", .{ .root_source_file = .{ .path = "src/main.zig" } });
 
     const main_tests = b.addTest(.{
         .root_source_file = .{ .path = "src/main.zig" },
@@ -25,7 +25,11 @@ pub fn build(b: *std.build.Builder) !void {
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&run_main_tests.step);
 
-    const fuzz_exe = b.addExecutable(.{ .name = "fuzz", .root_source_file = .{ .path = "src/fuzz.zig" } });
+    const fuzz_exe = b.addExecutable(.{
+        .name = "fuzz",
+        .root_source_file = .{ .path = "src/fuzz.zig" },
+        .target = target,
+    });
     fuzz_exe.linkLibC();
     b.installArtifact(fuzz_exe);
     const fuzz_compile_run = b.step("fuzz", "Build executable for fuzz testing afl-fuzz");

--- a/examples/serialize-custom/build.zig
+++ b/examples/serialize-custom/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
@@ -13,10 +13,10 @@ pub fn build(b: *std.build.Builder) void {
 
     // If we have the project in our repository then we can just add it as a module
     const tomlz = b.addModule("tomlz", .{
-        .source_file = .{ .path = "../../src/main.zig" },
+        .root_source_file = .{ .path = "../../src/main.zig" },
     });
 
-    exe.addModule("tomlz", tomlz);
+    exe.root_module.addImport("tomlz", tomlz);
 
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());

--- a/examples/serialize/build.zig
+++ b/examples/serialize/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
@@ -13,10 +13,10 @@ pub fn build(b: *std.build.Builder) void {
 
     // If we have the project in our repository then we can just add it as a module
     const tomlz = b.addModule("tomlz", .{
-        .source_file = .{ .path = "../../src/main.zig" },
+        .root_source_file = .{ .path = "../../src/main.zig" },
     });
 
-    exe.addModule("tomlz", tomlz);
+    exe.root_module.addImport("tomlz", tomlz);
 
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());

--- a/examples/simple/build.zig
+++ b/examples/simple/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
@@ -13,10 +13,10 @@ pub fn build(b: *std.build.Builder) void {
 
     // If we have the project in our repository then we can just add it as a module
     const tomlz = b.addModule("tomlz", .{
-        .source_file = .{ .path = "../../src/main.zig" },
+        .root_source_file = .{ .path = "../../src/main.zig" },
     });
 
-    exe.addModule("tomlz", tomlz);
+    exe.root_module.addImport("tomlz", tomlz);
 
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,37 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -18,26 +50,46 @@
         "type": "github"
       }
     },
-    "nixpkgs-zig-pinned": {
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1716097138,
-        "narHash": "sha256-IRcH9tH+YsR8PeBKS+/7OzSIyVofQDAtEqgJEAz6bLs=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717681334,
+        "narHash": "sha256-HlvsMH8BNgdmQCwbBDmWp5/DfkEQYhXZHagJQCgbJU0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "07c88f35d25ba5d0fff5074900582ce89c0d6ad0",
+        "rev": "31f40991012489e858517ec20102f033e4653afb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "07c88f35d25ba5d0fff5074900582ce89c0d6ad0",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs-zig-pinned": "nixpkgs-zig-pinned"
+        "nixpkgs": "nixpkgs",
+        "zig": "zig"
       }
     },
     "systems": {
@@ -52,6 +104,43 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "zig": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717719897,
+        "narHash": "sha256-sUWikeclHJxm4tCURmSF8uWly9FSpWmcfV2EvIhEH7Q=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "fd30d088a9171c3b865fb9f051460209523203aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,37 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -50,96 +18,26 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "nixpkgs-zig-pinned": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "zls",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "known-folders": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1659425144,
-        "narHash": "sha256-xMgdOKwWqBmw7avcioqQQrrPU1MjzlBMtNjqPfOEtDQ=",
-        "owner": "ziglibs",
-        "repo": "known-folders",
-        "rev": "24845b0103e611c108d6bc334231c464e699742c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ziglibs",
-        "repo": "known-folders",
-        "type": "github"
-      }
-    },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1698553279,
-        "narHash": "sha256-T/9P8yBSLcqo/v+FTOBK+0rjzjPMctVymZydbvR/Fak=",
+        "lastModified": 1716097138,
+        "narHash": "sha256-IRcH9tH+YsR8PeBKS+/7OzSIyVofQDAtEqgJEAz6bLs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90e85bc7c1a6fc0760a94ace129d3a1c61c3d035",
+        "rev": "07c88f35d25ba5d0fff5074900582ce89c0d6ad0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "07c88f35d25ba5d0fff5074900582ce89c0d6ad0",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "zig": "zig",
-        "zls": "zls"
+        "nixpkgs-zig-pinned": "nixpkgs-zig-pinned"
       }
     },
     "systems": {
@@ -154,95 +52,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "tres": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1672008284,
-        "narHash": "sha256-AtM9SV56PEud1MfbKDZMU2FlsNrI46PkcFQh3yMcDX0=",
-        "owner": "ziglibs",
-        "repo": "tres",
-        "rev": "16774b94efa61757a5302a690837dfb8cf750a11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ziglibs",
-        "repo": "tres",
-        "type": "github"
-      }
-    },
-    "zig": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1698754104,
-        "narHash": "sha256-y6kqewIIMwf9lI3jEMDBDA2N4DS1FQ632AnRifsMjoA=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "73fcf1bf79fa19d5b1e44b0787f107b270b1475b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
-      }
-    },
-    "zig-overlay": {
-      "inputs": {
-        "flake-utils": [
-          "zls",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "zls",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1672142864,
-        "narHash": "sha256-uXljuSZK8DP5c4o9u+gcF+Yc3dKYH1wsHmDpWcFBVRQ=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "16e9191142d2a13d7870c03e500842321a466a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
-      }
-    },
-    "zls": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "gitignore": "gitignore",
-        "known-folders": "known-folders",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "tres": "tres",
-        "zig-overlay": "zig-overlay"
-      },
-      "locked": {
-        "lastModified": 1673027149,
-        "narHash": "sha256-wwL1PGZGROIlk2eabEfA/FLs94OKrUTyNwRH5/bGyTQ=",
-        "owner": "erikarvstedt",
-        "repo": "zls",
-        "rev": "0f871c20847400abfd3e89539ae649b6cb903e66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "erikarvstedt",
-        "ref": "fix-nix",
-        "repo": "zls",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,25 +2,48 @@
   description = "A TOML library for Zig";
 
   inputs = {
-    # 0.12.0 is on revision 07c88f35d25ba5d0fff5074900582ce89c0d6ad0
-    # look at: https://lazamar.co.uk/nix-versions/?package=zig
-    nixpkgs-zig-pinned.url = "github:NixOS/nixpkgs/07c88f35d25ba5d0fff5074900582ce89c0d6ad0";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    zig = {
+      url = "github:mitchellh/zig-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    zls = {
+      url = "github:erikarvstedt/zls/fix-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs-zig-pinned, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system: {
-        devShell =
-          with nixpkgs-zig-pinned.legacyPackages.${system};
-          mkShell {
-            buildInputs = [
-              nixpkgs-zig-pinned.legacyPackages.${system}.zig
-              nixpkgs-zig-pinned.legacyPackages.${system}.zls
-              nixpkgs-zig-pinned.legacyPackages.${system}.lldb
-            ];
-            shellHook = ''
-              '';
-          };
-      }
-  );
+  outputs = {self, nixpkgs, flake-utils, flake-compat, zig, zls}:
+    let
+      overlays = [
+        (final: prev: {
+          zigpkgs = zig.packages.${prev.system};
+        })
+        (final: prev: {
+          zlspkgs = zls.packages.${prev.system};
+        })
+      ];
+      systems = builtins.attrNames zig.packages;
+    in
+      flake-utils.lib.eachSystem systems (system:
+        let
+          pkgs = import nixpkgs { inherit overlays system; };
+        in
+          rec {
+            devShell = pkgs.mkShell {
+              buildInputs = (with pkgs; [
+                zigpkgs.master-2023-10-30
+                zlspkgs.default
+                bashInteractive
+                gdb
+                lldb
+              ]);
+            };
+          }
+      );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,20 +12,13 @@
       url = "github:mitchellh/zig-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    zls = {
-      url = "github:erikarvstedt/zls/fix-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
-  outputs = {self, nixpkgs, flake-utils, flake-compat, zig, zls}:
+  outputs = {self, nixpkgs, flake-utils, flake-compat, zig}:
     let
       overlays = [
         (final: prev: {
           zigpkgs = zig.packages.${prev.system};
-        })
-        (final: prev: {
-          zlspkgs = zls.packages.${prev.system};
         })
       ];
       systems = builtins.attrNames zig.packages;
@@ -37,8 +30,8 @@
           rec {
             devShell = pkgs.mkShell {
               buildInputs = (with pkgs; [
-                zigpkgs.master-2023-10-30
-                zlspkgs.default
+                zigpkgs."0.12.0"
+                zls
                 bashInteractive
                 gdb
                 lldb

--- a/flake.nix
+++ b/flake.nix
@@ -2,48 +2,25 @@
   description = "A TOML library for Zig";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # 0.12.0 is on revision 07c88f35d25ba5d0fff5074900582ce89c0d6ad0
+    # look at: https://lazamar.co.uk/nix-versions/?package=zig
+    nixpkgs-zig-pinned.url = "github:NixOS/nixpkgs/07c88f35d25ba5d0fff5074900582ce89c0d6ad0";
     flake-utils.url = "github:numtide/flake-utils";
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
-    zig = {
-      url = "github:mitchellh/zig-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    zls = {
-      url = "github:erikarvstedt/zls/fix-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
-  outputs = {self, nixpkgs, flake-utils, flake-compat, zig, zls}:
-    let
-      overlays = [
-        (final: prev: { 
-          zigpkgs = zig.packages.${prev.system};
-        })
-        (final: prev: {
-          zlspkgs = zls.packages.${prev.system};
-        })
-      ];
-      systems = builtins.attrNames zig.packages;
-    in
-      flake-utils.lib.eachSystem systems (system:
-        let
-          pkgs = import nixpkgs { inherit overlays system; };
-        in
-          rec {
-            devShell = pkgs.mkShell {
-              buildInputs = (with pkgs; [
-                zigpkgs.master-2023-10-30
-                zlspkgs.default
-                bashInteractive
-                gdb
-                lldb
-              ]);
-            };
-          }
-      );
+  outputs = { self, nixpkgs-zig-pinned, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system: {
+        devShell =
+          with nixpkgs-zig-pinned.legacyPackages.${system};
+          mkShell {
+            buildInputs = [
+              nixpkgs-zig-pinned.legacyPackages.${system}.zig
+              nixpkgs-zig-pinned.legacyPackages.${system}.zls
+              nixpkgs-zig-pinned.legacyPackages.${system}.lldb
+            ];
+            shellHook = ''
+              '';
+          };
+      }
+  );
 }

--- a/src/fuzz.zig
+++ b/src/fuzz.zig
@@ -16,7 +16,7 @@ pub fn main() !void {
     const data = try stdin.readToEndAlloc(allocator, std.math.maxInt(usize));
     defer allocator.free(data);
 
-    var lexer = parser.Lexer{ .real = try lex.Lexer.init(allocator, data) };
+    const lexer = parser.Lexer{ .real = try lex.Lexer.init(allocator, data) };
     var p = try parser.Parser.init(allocator, lexer);
     defer p.deinit();
 

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -71,7 +71,7 @@ pub const Lexer = struct {
         if (!std.unicode.utf8ValidateSlice(src))
             return error.NotUTF8;
 
-        var arena = std.heap.ArenaAllocator.init(allocator);
+        const arena = std.heap.ArenaAllocator.init(allocator);
         return Lexer{ .arena = arena, .source = src, .loc = .{ .line = 1, .col = 1 }, .diag = null, .index = 0 };
     }
 
@@ -157,7 +157,7 @@ pub const Lexer = struct {
     /// parseEscapeChar parses the valid escape codes allowed in TOML (i.e. those allowed in a string beginning with a
     /// backslash)
     fn parseEscapeChar(self: *Lexer, al: *std.ArrayListUnmanaged(u8)) Error!void {
-        var c: u8 = switch (try self.peek()) {
+        const c: u8 = switch (try self.peek()) {
             'b' => 8,
             't' => '\t',
             'n' => '\n',
@@ -413,7 +413,7 @@ pub const Lexer = struct {
 
             if (c == '\r') {
                 _ = self.pop() catch unreachable;
-                var p = self.peek() catch |err| switch (err) {
+                const p = self.peek() catch |err| switch (err) {
                     error.EOF => {
                         self.diag = .{ .msg = "expected \\n after \\r", .loc = self.loc };
                         return error.UnexpectedChar;
@@ -549,7 +549,7 @@ pub const Lexer = struct {
             _ = self.pop() catch unreachable;
         }
 
-        var slice = self.source[original_index..self.index];
+        const slice = self.source[original_index..self.index];
         if (slice[slice.len - 1] == '.') {
             self.diag = .{ .msg = "trailing dot not allowed", .loc = self.loc };
             return error.UnexpectedChar;
@@ -602,7 +602,7 @@ pub const Lexer = struct {
     /// NOTE: any memory returned in TokLoc (e.g. the []const u8 array in a key/string) is only valid until the next
     /// call of next
     pub fn next(self: *Lexer, force_key: bool) Error!?TokLoc {
-        var child = self.arena.child_allocator;
+        const child = self.arena.child_allocator;
 
         self.arena.deinit();
         self.arena = std.heap.ArenaAllocator.init(child);
@@ -698,7 +698,7 @@ fn readAllTokens(src: []const u8) ![]const Tok {
 }
 
 fn testTokens(src: []const u8, expected: []const Tok) !void {
-    var toks = try readAllTokens(src);
+    const toks = try readAllTokens(src);
     defer {
         for (toks) |tok| {
             tok.deinit(testing.allocator);


### PR DESCRIPTION
Since zig 0.12.0 is out and I planned on starting a new project using this release, I noticed there are some problems when following the instructions, compiling and running tests.

Interesting changes:
- build has changed a bit
- some methods have changed, comptime `meta.trait` is gone
- float formatting removed `+`/`-` and leading `0` since zig stdlib moved to Ryu